### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,20 @@ jobs:
       # on Linux runners here; thinca/action-setup-vim installs a prebuilt
       # Vim on macOS / Windows. Both expose the same `executable` output,
       # coalesced into DENOPS_TEST_VIM_EXECUTABLE below.
-      - uses: rhysd/action-setup-vim@v1
+      - uses: rhysd/action-setup-vim@v1.6.1
         if: matrix.os == 'ubuntu-latest'
         id: vim-rhysd
         with:
           version: "v9.2.0148"
 
-      - uses: thinca/action-setup-vim@v3
+      - uses: thinca/action-setup-vim@v3.0.2
         if: matrix.os != 'ubuntu-latest'
         id: vim-thinca
         with:
           vim_type: "Vim"
           vim_version: "v9.2.0148"
 
-      - uses: rhysd/action-setup-vim@v1
+      - uses: rhysd/action-setup-vim@v1.6.1
         id: nvim
         with:
           neovim: true

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-24T14:13:51.7330411Z"
+applied_at = "2026-08-25T03:32:53.106563783Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -27,7 +27,7 @@ content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a
 content_hash = "0ac5ed2847ab6e1041e34209dcc2396a582722ea9537d03bd950e1db1851a4b7"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "ae4586f9d4b9e744ac86a6481e6ffc6411be46976ddb7cab322c8964841a6f29"
+content_hash = "8ec238516165f4c03c8cb08216b19afe379339dd4792406660d9e96ed9c23cf2"
 
 [files.".github/workflows/claude-review.yml"]
 content_hash = "4a8e47aabb3cdf2a59030d5194467022f0efb53bb1819d4495752020d10be773"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->