### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -3,7 +3,7 @@ applied_at = "2026-08-25T03:32:53.106563783Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "67b51ca20a19ec8347d7c2504585391725e7892f"
+rev = "6b66bd5112f42490d972b282585040f19d09ede4"
 version = "0.18.0"
 
 [[templates]]


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->